### PR TITLE
tokenをRoomRepositoryの引数にする

### DIFF
--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/AppModule.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/di/AppModule.kt
@@ -34,8 +34,9 @@ class AppModule(private val context: Context) {
     @Singleton
     @Provides
     fun provideRoomRepository(
-            api: SyncPodApi
-    ) : RoomRepository = RoomDataRepository(api)
+            api: SyncPodApi,
+            repository: UserRepository
+    ) : RoomRepository = RoomDataRepository(api, repository.getAccessToken().blockingGet()!!)
 
     companion object {
         const val APP_NAME = "youtube-sync"

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/RoomDataRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/RoomDataRepository.kt
@@ -12,9 +12,10 @@ import javax.inject.Inject
  * Created by chigichan24 on 2018/02/22.
  */
 class RoomDataRepository @Inject constructor(
-        private val syncPodApi: SyncPodApi
+        private val syncPodApi: SyncPodApi,
+        private val token: String
 ) : RoomRepository {
-    override fun fetch(id: Int, token: String): Single<Room?>? {
+    override fun fetch(id: Int): Single<Room?>? {
         return try {
             syncPodApi.getEnteredRooms(token)
                     .map { it.joinedRooms?.last() }
@@ -26,7 +27,7 @@ class RoomDataRepository @Inject constructor(
         }
     }
 
-    override fun fetchJoinedRooms(token: String): Single<List<Room>> {
+    override fun fetchJoinedRooms(): Single<List<Room>> {
         return syncPodApi.getEnteredRooms(token)
                 .map { it.joinedRooms }
                 .map { it.toModel() }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/RoomRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/RoomRepository.kt
@@ -7,6 +7,6 @@ import io.reactivex.Single
  * Created by chigichan24 on 2018/02/22.
  */
 interface RoomRepository {
-    fun fetchJoinedRooms(token: String): Single<List<Room>>
-    fun fetch(id: Int, token: String): Single<Room?>?
+    fun fetchJoinedRooms(): Single<List<Room>>
+    fun fetch(id: Int): Single<Room?>?
 }

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/TopActivityViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/TopActivityViewModel.kt
@@ -6,7 +6,6 @@ import android.databinding.ObservableField
 import android.databinding.ObservableList
 import com.cyder.atsushi.youtubesync.model.Room
 import com.cyder.atsushi.youtubesync.repository.RoomRepository
-import com.cyder.atsushi.youtubesync.repository.UserRepository
 import com.cyder.atsushi.youtubesync.view.helper.Navigator
 import com.cyder.atsushi.youtubesync.viewmodel.base.ActivityViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -17,7 +16,6 @@ import javax.inject.Inject
  */
 
 class TopActivityViewModel @Inject constructor(
-        private val userRepository: UserRepository,
         private val roomRepository: RoomRepository,
         private val navigator: Navigator
 ) : ActivityViewModel() {
@@ -49,8 +47,7 @@ class TopActivityViewModel @Inject constructor(
     }
 
     private fun getRooms() {
-        val token = userRepository.getAccessToken().blockingGet()!!
-        roomRepository.fetchJoinedRooms(token)
+        roomRepository.fetchJoinedRooms()
                 .map { convertToViewModel(it) }
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe ({ response ->


### PR DESCRIPTION
## Issues
+ Close #184 

## Overview
+ 前々から議論になっていた，`token`がUserに紐付いていていろいろめんどい問題があったので，RoomRepositoryを作る段階で渡すようにした．
 + そうすると，`ViewModel`で散財していたtoken問題を解決できる．
+ こうするとUser -> Room といった暗黙のdependencyができるが，これはアプリの性質上問題ないと思っている．
 + これが大きくなりそうならhelperとして切り出して使えるのを限定すればいいと思う．
 + まだ小さいので`token`だけを引数として切り出した．