### PR TITLE
VideoFragmentViewModelでのobserverWithInitPlayerのタイミングを変更

### DIFF
--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/VideoFragmentViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/VideoFragmentViewModel.kt
@@ -28,6 +28,10 @@ class VideoFragmentViewModel @Inject constructor(
     var nowProgress = ObservableInt(0)
     var maxProgress = ObservableInt(10000)
 
+    init {
+        observerWithInitPlayer()
+    }
+
     override fun onStart() {
         val key = videoRepository.developerKey.blockingFirst()
         val listener = videoRepository.playerState.blockingFirst()
@@ -47,8 +51,6 @@ class VideoFragmentViewModel @Inject constructor(
             override fun onInitializationFailure(provider: YouTubePlayer.Provider?, error: YouTubeInitializationResult?) {
             }
         })
-
-        observerWithInitPlayer()
     }
 
     override fun onResume() {

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/websocket/SyncPodWsApiImpl.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/websocket/SyncPodWsApiImpl.kt
@@ -102,7 +102,7 @@ class SyncPodWsApiImpl @Inject constructor(
     }
 
     override fun requestAddVideo(videoId: String) {
-        subscription.perform(ADD_VIDEO, mapOf(VIDEO_ID to videoId))
+        subscription?.perform(ADD_VIDEO, mapOf(VIDEO_ID to videoId))
     }
 
     private fun startRouting() {


### PR DESCRIPTION
じゃないと、永遠にストリームが増え続けてロード時間が無限に増え続けます。
もしかすると #223 が解決するかも？