### PR TITLE
cueに入ってる時に動画のタイトルが表示されないバグを修正

### DIFF
--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/VideoDataRepository.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/repository/VideoDataRepository.kt
@@ -65,7 +65,7 @@ class VideoDataRepository @Inject constructor(
     }
 
     override fun observePrepareVideo(): Flowable<Video> {
-        return playingVideo.toFlowable(BackpressureStrategy.LATEST)
+        return prepareVideo.toFlowable(BackpressureStrategy.LATEST)
     }
 
     override fun observeNowPlayingVideo(): Flowable<Video> {

--- a/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/PlayListFragmentViewModel.kt
+++ b/app/src/main/kotlin/com/cyder/atsushi/youtubesync/viewmodel/PlayListFragmentViewModel.kt
@@ -11,6 +11,7 @@ import com.cyder.atsushi.youtubesync.repository.VideoRepository
 import com.cyder.atsushi.youtubesync.view.helper.Navigator
 import com.cyder.atsushi.youtubesync.viewmodel.base.FragmentViewModel
 import io.reactivex.BackpressureStrategy
+import io.reactivex.Flowable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.subjects.PublishSubject
 import javax.inject.Inject
@@ -47,7 +48,10 @@ class PlayListFragmentViewModel @Inject constructor(
                     hasPlayList.set(videoViewModels.isNotEmpty())
                 }
 
-        repository.observeNowPlayingVideo()
+        Flowable.merge(
+                repository.observePrepareVideo(),
+                repository.observeNowPlayingVideo()
+        )
                 .takeUntil(onPauseSubject.toFlowable(BackpressureStrategy.LATEST))
                 .subscribe {
                     nowPlayVideo.set(it)


### PR DESCRIPTION
close #230 
再生準備中は動画名が表示されていなかったので、表示されるようにしました。
変な書き間違いがあって一瞬悩んだ