### PR TITLE
APILevel 19以下で起動すらできない問題

### DIFF
--- a/app/src/main/kotlin/com/cyder/android/syncpod/BaseApplication.kt
+++ b/app/src/main/kotlin/com/cyder/android/syncpod/BaseApplication.kt
@@ -1,6 +1,8 @@
 package com.cyder.android.syncpod
 
 import android.app.Application
+import android.content.Context
+import android.support.multidex.MultiDex
 import com.cyder.android.syncpod.di.AppComponent
 import com.cyder.android.syncpod.di.AppModule
 import com.cyder.android.syncpod.di.DaggerAppComponent
@@ -21,5 +23,10 @@ class BaseApplication : Application() {
                 .build()
         component.inject(this)
 
+    }
+
+    override fun attachBaseContext(base: Context?) {
+        super.attachBaseContext(base)
+        MultiDex.install(this)
     }
 }


### PR DESCRIPTION
Close #262 

MultiDexの設定は19以下では手動でやらないといけないらしい．


が，


起動はして，チャットは送れるが動画が再生されないので再調査．